### PR TITLE
Change model to half precision - fp16

### DIFF
--- a/nuke_dan.py
+++ b/nuke_dan.py
@@ -50,6 +50,7 @@ def main_model():
         map_location="cpu",
     )
     model.load_state_dict(state_dict)
+    model = model.half()
 
     return model.to(DEVICE).eval()
 
@@ -67,6 +68,10 @@ class DepthAnythingNuke(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         b, c, h, w = x.shape
+
+        if x.dtype == torch.float32:
+            x = x.half()
+
         n = [20, 21, 22, 23]  # n = 4 on the original code as 'blocks_to_take'
 
         # Padding

--- a/v1/layers/patch_embed.py
+++ b/v1/layers/patch_embed.py
@@ -11,6 +11,7 @@
 from typing import Callable, Optional, Tuple, Union
 
 from torch import Tensor
+import torch
 import torch.nn as nn
 
 
@@ -68,6 +69,10 @@ class PatchEmbed(nn.Module):
 
     def forward(self, x: Tensor) -> Tensor:
         _, _, H, W = x.shape
+
+        if x.dtype == torch.float32:
+            x = x.half()
+
         patch_H, patch_W = self.patch_size
 
         assert H % patch_H == 0, f"Input image height {H} is not a multiple of patch height {patch_H}"

--- a/v1/vision_transformer.py
+++ b/v1/vision_transformer.py
@@ -203,7 +203,7 @@ class DinoVisionTransformer(nn.Module):
             # (int(w0), int(h0)), # to solve the upsampling shape issue
             mode="bicubic",
             align_corners=False,
-            recompute_scale_factor=None,
+            recompute_scale_factor=True,
         )
         assert int(w0) == patch_pos_embed.shape[-2]
         assert int(h0) == patch_pos_embed.shape[-1]


### PR DESCRIPTION
Reducing precision to FP16 boosts performance significantly, allowing larger images to be processed, with negligible quality loss in most shots.